### PR TITLE
update big data bundle

### DIFF
--- a/src/example.html
+++ b/src/example.html
@@ -40,7 +40,7 @@
           <div class="juju-card" data-id="realtime-syslog-analytics" data-dd></div>
         </div>
         <div class="col-4 card">
-          <div class="juju-card" data-id="~bigdata-charmers/apache-hadoop-spark-zeppelin" data-dd></div>
+          <div class="juju-card" data-id="spark-processing" data-dd></div>
         </div>
       </div>
 


### PR DESCRIPTION
The apache-hadoop-spark-zeppelin is no longer maintained.  I suggest replacing this with our spark-processing bundle.